### PR TITLE
Flash Error Syntax

### DIFF
--- a/grails-app/controllers/spud/media/MediaController.groovy
+++ b/grails-app/controllers/spud/media/MediaController.groovy
@@ -28,7 +28,10 @@ class MediaController {
         media.siteId = spudMultiSiteService.activeSite.siteId
 
         if(!media.save(flush:true)) {
-            flash.error("Error Uploading Attachment")
+            media.errors.each {
+                log.debug("Error Uploading Attachment \n${it}")
+            }
+            flash.error = "Error Uploading Attachment"
             redirect resource: 'media', namespace: 'spud_admin', action: 'index'
             return
         }


### PR DESCRIPTION
Fixed bad syntax on flash.error causing 500 on save fail. Added log.debug for the error event.
